### PR TITLE
feat: implement custom Material3 theme with light and dark color schemes

### DIFF
--- a/app/src/main/java/com/uniandes/sport/ui/theme/Theme.kt
+++ b/app/src/main/java/com/uniandes/sport/ui/theme/Theme.kt
@@ -78,8 +78,8 @@ fun UniandesSportsKotlinTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            window.statusBarColor = colorScheme.background.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 


### PR DESCRIPTION
Before:
<img width="1080" height="642" alt="image" src="https://github.com/user-attachments/assets/3c837e11-4388-45d2-bf49-9665883398c6" />
<img width="1080" height="335" alt="image" src="https://github.com/user-attachments/assets/d1ea4da8-aa7b-478b-b68f-7c98ae24a3d6" />

Now:
<img width="1080" height="309" alt="image" src="https://github.com/user-attachments/assets/7c48eae7-d624-49c9-a8ad-5ba26e216caf" />
<img width="1080" height="256" alt="image" src="https://github.com/user-attachments/assets/a2918cb6-4128-4a2f-aaf6-9b327aff9aa7" />

