### PR TITLE
Improve Social wall feed UX and posting experience

### DIFF
--- a/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetCard.kt
+++ b/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetCard.kt
@@ -1,61 +1,91 @@
 package com.uniandes.sport.ui.screens.wallscreen
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.uniandes.sport.models.Tweet
 import com.uniandes.sport.models.TweetType
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
 fun TweetCard(tweet: Tweet) {
-    Row(
+    Card(
         modifier = Modifier
-            .padding(8.dp)
             .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
     ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
 
-        Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(8.dp))
 
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = tweet.userName,
-                style = MaterialTheme.typography.subtitle1.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.padding(top = 4.dp, end = 8.dp, bottom = 4.dp)
-            )
-
-            if (tweet.type == TweetType.TEXT) {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = tweet.message,
-                    style = MaterialTheme.typography.body1,
-                    modifier = Modifier.padding(top = 4.dp, end = 8.dp, bottom = 4.dp)
+                    text = tweet.userName.ifBlank { "Anonymous athlete" },
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-            } else if (tweet.type == TweetType.IMAGE) {
-                val imageLoader = rememberImagePainter(
-                    data = tweet.message,
-                    builder = {
-                        crossfade(true)
-                    }
+                Text(
+                    text = formatTweetTimestamp(tweet.timestamp),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp)
                 )
-                Image(
-                    painter = imageLoader,
-                    contentDescription = "Tweet Image",
-                    modifier = Modifier
-                        .padding(top = 4.dp, end = 8.dp, bottom = 4.dp)
-                        .size(350.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                )
+
+                if (tweet.type == TweetType.TEXT) {
+                    Text(
+                        text = tweet.message,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                } else if (tweet.type == TweetType.IMAGE) {
+                    val imageLoader = rememberImagePainter(
+                        data = tweet.message,
+                        builder = {
+                            crossfade(true)
+                        }
+                    )
+                    Image(
+                        painter = imageLoader,
+                        contentDescription = "Tweet Image",
+                        modifier = Modifier
+                            .padding(top = 8.dp)
+                            .fillMaxWidth()
+                            .heightIn(min = 180.dp, max = 320.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                    )
+                }
             }
         }
+    }
+}
+
+private fun formatTweetTimestamp(rawTimestamp: String): String {
+    return try {
+        val parser = DateTimeFormatter.ofPattern("yyyyMMddHHmmss", Locale.getDefault())
+        val formatter = DateTimeFormatter.ofPattern("MMM d, yyyy • HH:mm", Locale.getDefault())
+        LocalDateTime.parse(rawTimestamp, parser).format(formatter)
+    } catch (_: Exception) {
+        rawTimestamp
     }
 }

--- a/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetForm.kt
+++ b/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetForm.kt
@@ -2,25 +2,25 @@ package com.uniandes.sport.ui.screens.wallscreen
 
 import android.Manifest
 import android.graphics.Bitmap
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Icon
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Send
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -31,8 +31,6 @@ import com.uniandes.sport.viewmodels.log.LogViewModelInterface
 import com.uniandes.sport.viewmodels.storage.StorageViewModelInterface
 import com.uniandes.sport.viewmodels.tweets.TweetsViewModelInterface
 import java.text.SimpleDateFormat
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.*
 
 
@@ -48,6 +46,7 @@ fun TweetForm(
 ) {
     val screenName = "TweetForm"
     val (tweetText, setTweetText) = remember { mutableStateOf("") }
+    val maxLength = 240
 
     val takePictureLauncher = rememberLauncherForActivityResult(contract = ActivityResultContracts.TakePicturePreview()) { bitmap ->
         if (bitmap != null) {
@@ -81,52 +80,62 @@ fun TweetForm(
         }
     }
 
-    Column(modifier = modifier
-        .padding(horizontal = 2.dp, vertical = 2.dp)
-        .imePadding()
+    Column(
+        modifier = modifier
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .imePadding()
     ) {
-        Row(modifier = Modifier.weight(1f)) {
-            OutlinedTextField(
-                value = tweetText,
-                onValueChange = { setTweetText(it) },
-                modifier = Modifier
-                    .padding(16.dp)
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .heightIn(min = 120.dp, max = 120.dp),
-                label = { Text(text = "Write your tweet") },
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Text,
-                    imeAction = ImeAction.Done
-                ),
-                keyboardActions = KeyboardActions(onDone = {}),
-                maxLines = Int.MAX_VALUE,
-                singleLine = false
-            )
-        }
+        OutlinedTextField(
+            value = tweetText,
+            onValueChange = { if (it.length <= maxLength) setTweetText(it) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 110.dp, max = 140.dp),
+            label = { Text(text = "Share something with the community") },
+            placeholder = { Text("How was your workout today?") },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(onDone = {}),
+            maxLines = 5,
+            shape = RoundedCornerShape(14.dp),
+            singleLine = false
+        )
+
+        Text(
+            text = "${tweetText.length}/$maxLength",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .align(Alignment.End)
+                .padding(top = 6.dp)
+        )
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            TextButton(
+            Button(
                 onClick = {
                     requestPermissionLauncher.launch(Manifest.permission.CAMERA)
                 },
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.outlinedButtonColors()
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                        imageVector = Icons.Filled.AccountBox,
+                        imageVector = Icons.Filled.CameraAlt,
                         contentDescription = "Image button",
                         modifier = Modifier.size(24.dp)
                     )
-                    Text("Send Image")
+                    Text("Photo", modifier = Modifier.padding(start = 6.dp))
                 }
             }
 
-            TextButton(
+            Button(
                 onClick = {
                     sendTweet(
                         tweetText = tweetText,
@@ -140,7 +149,9 @@ fun TweetForm(
                         setTweetText = setTweetText
                     )
                 },
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                enabled = tweetText.isNotBlank(),
+                shape = RoundedCornerShape(12.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
@@ -148,7 +159,7 @@ fun TweetForm(
                         contentDescription = "Send tweet button",
                         modifier = Modifier.size(24.dp)
                     )
-                    Text("Send")
+                    Text("Post", modifier = Modifier.padding(start = 6.dp), fontWeight = FontWeight.Bold)
                 }
             }
         }

--- a/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetList.kt
+++ b/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/TweetList.kt
@@ -1,20 +1,55 @@
 package com.uniandes.sport.ui.screens.wallscreen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.Divider
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.uniandes.sport.models.Tweet
-import com.uniandes.sport.viewmodels.storage.StorageViewModelInterface
 
 
 @Composable
-fun TweetList(tweets: List<Tweet>, modifier: Modifier) {
-    LazyColumn(modifier = modifier) {
-        itemsIndexed(tweets) { _, tweet ->
+fun TweetList(
+    tweets: List<Tweet>,
+    isLoading: Boolean,
+    listState: LazyListState,
+    modifier: Modifier
+) {
+    when {
+        isLoading -> {
+            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        tweets.isEmpty() -> {
+            Box(modifier = modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "No posts yet. Be the first to share an update with your community.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+        else -> LazyColumn(
+            state = listState,
+            modifier = modifier,
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(tweets, key = { it.id }) { tweet ->
             TweetCard(tweet)
-            Divider()
+            }
         }
     }
 }

--- a/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/WallScreen.kt
+++ b/app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/WallScreen.kt
@@ -2,10 +2,14 @@ package com.uniandes.sport.ui.screens.wallscreen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -29,9 +33,16 @@ fun WallScreen(
     val screenName = "WallScreen"
     var showErrorDialog by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
-    
-    // Simplificación para el estado de los tweets (MVVM)
-    val tweets = fetchTweetsAsState(tweetsViewModel, { errorMessage = it }, { showErrorDialog = it }, logViewModel)
+    var refreshKey by remember { mutableStateOf(0) }
+
+    val feedState = fetchTweetsAsState(
+        refreshKey = refreshKey,
+        tweetsViewModel = tweetsViewModel,
+        setErrorMessage = { errorMessage = it },
+        setShowErrorDialog = { showErrorDialog = it },
+        logViewModel = logViewModel
+    )
+    val listState = rememberLazyListState()
 
     Scaffold(
         topBar = {
@@ -40,14 +51,25 @@ fun WallScreen(
                     Column {
                         Text("COMMUNITY FEED", fontWeight = FontWeight.Black, fontSize = 18.sp)
                         Text(
-                            text = "POSTS AND UPDATES",
+                            text = "${feedState.tweets.size} posts and updates",
                             fontWeight = FontWeight.Bold,
                             fontSize = 10.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
                     }
                 },
                 actions = {
+                    IconButton(
+                        onClick = { refreshKey++ },
+                        enabled = !feedState.isLoading
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Refresh,
+                            contentDescription = "Refresh feed"
+                        )
+                    }
                     TextButton(onClick = {
                         authViewModel.logout(onSuccess = {
                             navController.navigate(Routes.AUTH_SCREEN) {
@@ -74,7 +96,12 @@ fun WallScreen(
                 .padding(paddingValues)
         ) {
             Box(modifier = Modifier.weight(1f)) {
-                TweetList(tweets, modifier = Modifier.fillMaxSize())
+                TweetList(
+                    tweets = feedState.tweets,
+                    isLoading = feedState.isLoading,
+                    modifier = Modifier.fillMaxSize(),
+                    listState = listState
+                )
             }
             
             Divider(color = Color(0xFFE5E7EB))
@@ -114,24 +141,36 @@ fun WallScreen(
 
 @Composable
 fun fetchTweetsAsState(
+    refreshKey: Int,
     tweetsViewModel: TweetsViewModelInterface,
     setErrorMessage: (String) -> Unit,
     setShowErrorDialog: (Boolean) -> Unit,
     logViewModel: LogViewModelInterface
-): List<Tweet> {
+): TweetFeedState {
     val screenName = "WallScreen"
     var tweets by remember { mutableStateOf(emptyList<Tweet>()) }
+    var isLoading by remember { mutableStateOf(true) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(refreshKey) {
+        isLoading = true
         tweetsViewModel.fetchTweets(
-            onSuccess = { fetchedTweets -> tweets = fetchedTweets },
+            onSuccess = { fetchedTweets ->
+                tweets = fetchedTweets
+                isLoading = false
+            },
             onFailure = { exception -> 
                 setErrorMessage(exception.message ?: "Unknown error")
                 setShowErrorDialog(true)
                 logViewModel.crash(screenName, exception)
+                isLoading = false
             }
         )
     }
 
-    return tweets
+    return TweetFeedState(tweets = tweets, isLoading = isLoading)
 }
+
+data class TweetFeedState(
+    val tweets: List<Tweet>,
+    val isLoading: Boolean
+)


### PR DESCRIPTION
### Motivation
- Make the Social (Wall) screen more usable by surfacing loading/empty states and allowing manual refresh of the feed. 
- Improve readability and consistency of individual posts (cards) and make the composer clearer and safer to use.

### Description
- Introduced a feed state model (`TweetFeedState`) and a refresh key to support loading state and manual refresh in `WallScreen` and replaced the previous simple list usage with `fetchTweetsAsState` that returns `tweets` + `isLoading`.
- Reworked the list into `TweetList` to show a centered `CircularProgressIndicator` when loading, an empty-state message when there are no posts, and a keyed, spaced `LazyColumn` for content; accepts `listState` for stable scroll behavior.
- Redesigned `TweetCard` to use Material 3 `Card` styling, added formatted timestamps, fallback author name, constrained image sizing, and improved typography and spacing.
- Improved `TweetForm` UX by adding a 240-character limit with a counter, placeholder text, rounded inputs, updated action buttons (`Photo` / `Post`), and disabling the post button when the text is blank.
- Files changed: `app/src/main/java/com/uniandes/sport/ui/screens/wallscreen/WallScreen.kt`, `TweetList.kt`, `TweetCard.kt`, `TweetForm.kt`.

### Testing
- Ran `git diff --check` and there were no style/merge issues (success).
- Attempted to run `./gradlew :app:compileDebugKotlin` but it failed in this environment due to Gradle wrapper download being blocked by an external proxy (HTTP 403), so compile could not be verified here (environment limitation).
